### PR TITLE
Fix sqlite RenameIndex migrations

### DIFF
--- a/integrated_channels/blackboard/migrations/0024_rename_blackboardlearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_black.py
+++ b/integrated_channels/blackboard/migrations/0024_rename_blackboardlearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_black.py
@@ -3,30 +3,31 @@
 from django.db import migrations, connection
 
 
-def noop_for_sqlite(apps, schema_editor):
-    """
-    No-op function for SQLite to avoid running the RenameIndex operation.
-    This is a placeholder function that does nothing.
-    """
-    pass
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
         ('blackboard', '0023_auto_20240604_1046'),
     ]
 
-    operations = []
-    # Only run RenameIndex on non-SQLite:
+    database_operations = []
     if connection.vendor != 'sqlite':
-        operations.append(
+        database_operations.append(
             migrations.RenameIndex(
                 model_name='blackboardlearnerdatatransmissionaudit',
                 old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
                 new_name='blackboard_customer_plugin_idx',
             )
         )
-    else:
-        # Noop on SQLite, and let your Meta.indexes definition create the index
-        operations.append(migrations.RunPython(noop_for_sqlite))
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=database_operations,
+            state_operations=[
+                migrations.RenameIndex(
+                    model_name='blackboardlearnerdatatransmissionaudit',
+                    old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
+                    new_name='blackboard_customer_plugin_idx',
+                ),
+            ],
+        )
+    ]

--- a/integrated_channels/canvas/migrations/0040_rename_canvaslearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_canvas_cu.py
+++ b/integrated_channels/canvas/migrations/0040_rename_canvaslearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_canvas_cu.py
@@ -3,30 +3,31 @@
 from django.db import migrations, connection
 
 
-def noop_for_sqlite(apps, schema_editor):
-    """
-    No-op function for SQLite to avoid running the RenameIndex operation.
-    This is a placeholder function that does nothing.
-    """
-    pass
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
         ('canvas', '0039_remove_canvasenterprisecustomerconfiguration_client_id_and_more'),
     ]
 
-    operations = []
-    # Only run RenameIndex on non-SQLite:
+    database_operations = []
     if connection.vendor != 'sqlite':
-        operations.append(
+        database_operations.append(
             migrations.RenameIndex(
                 model_name='canvaslearnerdatatransmissionaudit',
                 new_name='canvas_customer_plugin_idx',
                 old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
             ),
         )
-    else:
-        # Noop on SQLite, and let your Meta.indexes definition create the index
-        operations.append(migrations.RunPython(noop_for_sqlite))
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=database_operations,
+            state_operations=[
+                migrations.RenameIndex(
+                    model_name='canvaslearnerdatatransmissionaudit',
+                    new_name='canvas_customer_plugin_idx',
+                    old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
+                ),
+            ],
+        )
+    ]

--- a/integrated_channels/cornerstone/migrations/0035_rename_cornerstonelearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_corn.py
+++ b/integrated_channels/cornerstone/migrations/0035_rename_cornerstonelearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_corn.py
@@ -3,30 +3,31 @@
 from django.db import migrations, connection
 
 
-def noop_for_sqlite(apps, schema_editor):
-    """
-    No-op function for SQLite to avoid running the RenameIndex operation.
-    This is a placeholder function that does nothing.
-    """
-    pass
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
         ('cornerstone', '0034_cornerstonelearnerdatatransmissionaudit_is_transmitted'),
     ]
 
-    operations = []
-    # Only run RenameIndex on non-SQLite:
+    database_operations = []
     if connection.vendor != 'sqlite':
-        operations.append(
+        database_operations.append(
             migrations.RenameIndex(
                 model_name='cornerstonelearnerdatatransmissionaudit',
                 new_name='corner_customer_plugin_idx',
                 old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
             ),
         )
-    else:
-        # Noop on SQLite, and let your Meta.indexes definition create the index
-        operations.append(migrations.RunPython(noop_for_sqlite))
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=database_operations,
+            state_operations=[
+                migrations.RenameIndex(
+                    model_name='cornerstonelearnerdatatransmissionaudit',
+                    new_name='corner_customer_plugin_idx',
+                    old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
+                ),
+            ],
+        )
+    ]

--- a/integrated_channels/degreed/migrations/0034_rename_degreedlearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_degreed_.py
+++ b/integrated_channels/degreed/migrations/0034_rename_degreedlearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_degreed_.py
@@ -3,30 +3,31 @@
 from django.db import migrations, connection
 
 
-def noop_for_sqlite(apps, schema_editor):
-    """
-    No-op function for SQLite to avoid running the RenameIndex operation.
-    This is a placeholder function that does nothing.
-    """
-    pass
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
         ('degreed', '0033_degreedlearnerdatatransmissionaudit_is_transmitted'),
     ]
 
-    operations = []
-    # Only run RenameIndex on non-SQLite:
+    database_operations = []
     if connection.vendor != 'sqlite':
-        operations.append(
+        database_operations.append(
             migrations.RenameIndex(
                 model_name='degreedlearnerdatatransmissionaudit',
                 new_name='degreed_customer_plugin_idx',
                 old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
             ),
         )
-    else:
-        # Noop on SQLite, and let your Meta.indexes definition create the index
-        operations.append(migrations.RunPython(noop_for_sqlite))
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=database_operations,
+            state_operations=[
+                migrations.RenameIndex(
+                    model_name='degreedlearnerdatatransmissionaudit',
+                    new_name='degreed_customer_plugin_idx',
+                    old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
+                ),
+            ],
+        )
+    ]

--- a/integrated_channels/degreed2/migrations/0030_rename_degreed2learnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_degreed.py
+++ b/integrated_channels/degreed2/migrations/0030_rename_degreed2learnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_degreed.py
@@ -3,30 +3,31 @@
 from django.db import migrations, connection
 
 
-def noop_for_sqlite(apps, schema_editor):
-    """
-    No-op function for SQLite to avoid running the RenameIndex operation.
-    This is a placeholder function that does nothing.
-    """
-    pass
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
         ('degreed2', '0029_degreed2learnerdatatransmissionaudit_is_transmitted'),
     ]
 
-    operations = []
-    # Only run RenameIndex on non-SQLite:
+    database_operations = []
     if connection.vendor != 'sqlite':
-        operations.append(
+        database_operations.append(
             migrations.RenameIndex(
                 model_name='degreed2learnerdatatransmissionaudit',
                 new_name='degreed2_customer_plugin_idx',
                 old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
             ),
         )
-    else:
-        # Noop on SQLite, and let your Meta.indexes definition create the index
-        operations.append(migrations.RunPython(noop_for_sqlite))
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=database_operations,
+            state_operations=[
+                migrations.RenameIndex(
+                    model_name='degreed2learnerdatatransmissionaudit',
+                    new_name='degreed2_customer_plugin_idx',
+                    old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
+                ),
+            ],
+        )
+    ]

--- a/integrated_channels/moodle/migrations/0035_rename_moodlelearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_moodle_cu.py
+++ b/integrated_channels/moodle/migrations/0035_rename_moodlelearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_moodle_cu.py
@@ -3,30 +3,31 @@
 from django.db import migrations, connection
 
 
-def noop_for_sqlite(apps, schema_editor):
-    """
-    No-op function for SQLite to avoid running the RenameIndex operation.
-    This is a placeholder function that does nothing.
-    """
-    pass
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
         ('moodle', '0034_moodlelearnerdatatransmissionaudit_is_transmitted'),
     ]
 
-    operations = []
-    # Only run RenameIndex on non-SQLite:
+    database_operations = []
     if connection.vendor != 'sqlite':
-        operations.append(
+        database_operations.append(
             migrations.RenameIndex(
                 model_name='moodlelearnerdatatransmissionaudit',
                 new_name='moodle_customer_plugin_idx',
                 old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
             ),
         )
-    else:
-        # Noop on SQLite, and let your Meta.indexes definition create the index
-        operations.append(migrations.RunPython(noop_for_sqlite))
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=database_operations,
+            state_operations=[
+                migrations.RenameIndex(
+                    model_name='moodlelearnerdatatransmissionaudit',
+                    new_name='moodle_customer_plugin_idx',
+                    old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
+                ),
+            ],
+        )
+    ]

--- a/integrated_channels/sap_success_factors/migrations/0025_rename_sapsuccessfactorslearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_i.py
+++ b/integrated_channels/sap_success_factors/migrations/0025_rename_sapsuccessfactorslearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_i.py
@@ -3,30 +3,31 @@
 from django.db import migrations, connection
 
 
-def noop_for_sqlite(apps, schema_editor):
-    """
-    No-op function for SQLite to avoid running the RenameIndex operation.
-    This is a placeholder function that does nothing.
-    """
-    pass
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
         ('sap_success_factors', '0024_auto_20240909_1614'),
     ]
 
-    operations = []
-    # Only run RenameIndex on non-SQLite:
+    database_operations = []
     if connection.vendor != 'sqlite':
-        operations.append(
+        database_operations.append(
             migrations.RenameIndex(
                 model_name='sapsuccessfactorslearnerdatatransmissionaudit',
                 new_name='success_customer_plugin_idx',
                 old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
             ),
         )
-    else:
-        # Noop on SQLite, and let your Meta.indexes definition create the index
-        operations.append(migrations.RunPython(noop_for_sqlite))
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=database_operations,
+            state_operations=[
+                migrations.RenameIndex(
+                    model_name='sapsuccessfactorslearnerdatatransmissionaudit',
+                    new_name='success_customer_plugin_idx',
+                    old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
+                ),
+            ],
+        )
+    ]

--- a/integrated_channels/xapi/migrations/0013_rename_xapilearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_xapi_custom.py
+++ b/integrated_channels/xapi/migrations/0013_rename_xapilearnerdatatransmissionaudit_enterprise_customer_uuid_plugin_configuration_id_xapi_custom.py
@@ -3,30 +3,31 @@
 from django.db import migrations, connection
 
 
-def noop_for_sqlite(apps, schema_editor):
-    """
-    No-op function for SQLite to avoid running the RenameIndex operation.
-    This is a placeholder function that does nothing.
-    """
-    pass
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
         ('xapi', '0012_xapilearnerdatatransmissionaudit_is_transmitted'),
     ]
 
-    operations = []
-    # Only run RenameIndex on non-SQLite:
+    database_operations = []
     if connection.vendor != 'sqlite':
-        operations.append(
+        database_operations.append(
             migrations.RenameIndex(
                 model_name='xapilearnerdatatransmissionaudit',
                 new_name='xapi_customer_plugin_idx',
                 old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
             ),
         )
-    else:
-        # Noop on SQLite, and let your Meta.indexes definition create the index
-        operations.append(migrations.RunPython(noop_for_sqlite))
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=database_operations,
+            state_operations=[
+                migrations.RenameIndex(
+                    model_name='xapilearnerdatatransmissionaudit',
+                    new_name='xapi_customer_plugin_idx',
+                    old_fields=('enterprise_customer_uuid', 'plugin_configuration_id'),
+                ),
+            ],
+        )
+    ]


### PR DESCRIPTION
## Summary
- skip RenameIndex DB operations when running on SQLite
- keep migration state consistent so makemigrations doesn't create extra files

## Testing
- `python manage.py makemigrations --check --dry-run`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68493bf7ab88832e8d072f89b75b6d6a